### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/tianyue525/73de69de-f800-4c1d-a6d7-e3f6a15fd022/889c16ea-8c95-4d56-9317-4e5a2e119385/_apis/work/boardbadge/2d5ccf6a-05ce-41bd-8b09-f2d7748c2a38)](https://dev.azure.com/tianyue525/73de69de-f800-4c1d-a6d7-e3f6a15fd022/_boards/board/t/889c16ea-8c95-4d56-9317-4e5a2e119385/Microsoft.RequirementCategory)
 # react-plain-text


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/tianyue525/73de69de-f800-4c1d-a6d7-e3f6a15fd022/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.